### PR TITLE
Enhacements

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,12 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { notFound } from 'next/navigation';
 import React from 'react';
 
 import DashboardKpis from '@/components/dashboard/dashboard-kpis';
 import DatePickerWithURLParams from '@/components/ui/date-picker/date-picker-with-url-params';
+import { authOptions, dashboardAllowedEmails } from '@/lib/auth';
 import { getDashboard } from '@/lib/dashboards';
 import { getReceiptsBalancePerYear } from '@/lib/receipts';
 import { PageProps } from '@/types';
 
-export default function Dashboard({ searchParams }: PageProps) {
+export default async function Dashboard({ searchParams }: PageProps) {
+  const session = await getServerSession(authOptions);
+  const userEmail = session?.user?.email;
+
+  if (!userEmail || !dashboardAllowedEmails.includes(userEmail)) {
+    notFound();
+  }
   const dashboardPromise = getDashboard(searchParams);
   const receiptsPromise = getReceiptsBalancePerYear(searchParams);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
       <body className={`${inter.className} flex`}>
         <ThemeProvider attribute='class' defaultTheme='system' enableSystem disableTransitionOnChange>
           <div className='flex h-screen w-full'>
-            <Sidebar />
+            <Sidebar userEmail={session?.user?.email} />
             <div className='flex-1 flex flex-col overflow-hidden'>
               <TopNavigationBar user={session?.user} />
               <main className='p-6 overflow-auto'>{children}</main>

--- a/src/components/common/sidebar/sidebar.tsx
+++ b/src/components/common/sidebar/sidebar.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { FiClipboard, FiDollarSign, FiLock, FiMonitor, FiSmile, FiTrendingUp } from 'react-icons/fi';
 import { TfiReceipt } from 'react-icons/tfi';
 
+import { dashboardAllowedEmails } from '@/lib/auth';
 import { cn } from '@/lib/utils';
 
 import Logo from './logo';
@@ -14,7 +15,7 @@ import Logo from './logo';
 const LinkItems = [
   { name: 'Estudiantes', icon: <FiSmile />, href: '/students' },
   { name: 'Cursos', icon: <FiMonitor />, href: '/courses' },
-  { name: 'Resumen', icon: <FiTrendingUp />, href: '/dashboard' },
+  { name: 'Resumen', icon: <FiTrendingUp />, href: '/dashboard', allowedEmails: dashboardAllowedEmails },
   { name: 'Caja', icon: <FiLock />, href: '/cash-register' },
   { name: 'Comprobantes', icon: <TfiReceipt />, href: '/receipts' },
   { name: 'Vencimientos', icon: <FiDollarSign />, href: '/expirations?sortBy=expiredAt&sortOrder=asc' },
@@ -57,8 +58,17 @@ const Ilustration = ({ path }: { path: string }) => {
   return <Image src={src} width={200} height={200} alt='Ilustration' />;
 };
 
-export default function Sidebar() {
+interface SidebarProps {
+  userEmail?: string | null;
+}
+
+export default function Sidebar({ userEmail }: SidebarProps) {
   const path = usePathname();
+
+  const visibleLinks = LinkItems.filter(
+    (item) => !item.allowedEmails || (userEmail && item.allowedEmails.includes(userEmail))
+  );
+
   return (
     <div className='w-60 flex flex-col border-r bg-gray-100/40 dark:bg-gray-800/40 items-center justify-between'>
       <div className='w-full'>
@@ -66,7 +76,7 @@ export default function Sidebar() {
           <Logo />
         </div>
         <nav className='grid items-start px-4 py-6 text-sm font-medium'>
-          {LinkItems.map(({ name, icon, href }) => (
+          {visibleLinks.map(({ name, icon, href }) => (
             <NavItem key={name} icon={icon} href={href} path={path}>
               {name}
             </NavItem>

--- a/src/components/invoices/invoice-state-badge.tsx
+++ b/src/components/invoices/invoice-state-badge.tsx
@@ -18,8 +18,24 @@ const invoicesStatus: InvoicesStatusType = {
   }
 };
 
-export default function InvoiceStateBadge({ state }: { state: Invoice['state'] }) {
+type InvoiceStateBadgeProps = {
+  state: Invoice['state'];
+  receiptId?: number;
+};
+
+export default function InvoiceStateBadge({ state, receiptId }: InvoiceStateBadgeProps) {
   const { color, text } = invoicesStatus[state];
+
+  if (state === 'P' && receiptId) {
+    return (
+      <a href={`/receipts?receiptId=${receiptId}`} target='_blank' rel='noopener noreferrer'>
+        <Badge variant={color} className='font-semibold underline cursor-pointer'>
+          {text}
+        </Badge>
+      </a>
+    );
+  }
+
   return (
     <Badge variant={color} className='font-semibold'>
       {text}

--- a/src/components/students/student-invoices-table/columns.tsx
+++ b/src/components/students/student-invoices-table/columns.tsx
@@ -2,6 +2,8 @@
 
 import { Invoice } from '@prisma/client';
 import { ColumnDef } from '@tanstack/react-table';
+
+type InvoiceWithReceipt = Invoice & { items: { receiptId: number }[] };
 import { MoreHorizontal } from 'lucide-react';
 
 import EditInvoiceDialog from '@/components/invoices/edit-invoice-dialog';
@@ -18,7 +20,7 @@ import {
 import { formatCurrency, formatPercentage, getMonthName } from '@/lib/utils';
 import { getDiscountedAmount } from '@/lib/utils/invoices.utils';
 
-export const columns: ColumnDef<Invoice>[] = [
+export const columns: ColumnDef<InvoiceWithReceipt>[] = [
   {
     accessorKey: 'description',
     header: ({ column }) => <DataTableColumnHeader column={column} title='Descripción' />
@@ -68,7 +70,10 @@ export const columns: ColumnDef<Invoice>[] = [
   {
     accessorKey: 'state',
     header: ({ column }) => <DataTableColumnHeader column={column} title='Estado' />,
-    cell: ({ row }) => <InvoiceStateBadge state={row.original.state} />
+    cell: ({ row }) => {
+      const receiptId = row.original.items?.[0]?.receiptId;
+      return <InvoiceStateBadge state={row.original.state} receiptId={receiptId} />;
+    }
   },
   {
     id: 'actions',

--- a/src/components/students/student-invoices-table/student-invoices-table.tsx
+++ b/src/components/students/student-invoices-table/student-invoices-table.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Invoice } from '@prisma/client';
 import React from 'react';
 
 import DataTable from '@/components/ui/data-table/data-table';
@@ -16,7 +15,7 @@ type StudentInvoicesTableProps = {
 export default function StudentInvoicesTable({ invoicesPromise }: StudentInvoicesTableProps) {
   const { invoices, totalPages } = React.use(invoicesPromise);
 
-  const table = useURLManagedDataTable<Invoice>({
+  const table = useURLManagedDataTable({
     data: invoices,
     columns,
     pageCount: totalPages

--- a/src/components/students/students-table/students-table-filters.tsx
+++ b/src/components/students/students-table/students-table-filters.tsx
@@ -70,7 +70,7 @@ export default function StudentsTableFilters({ table, courseOptions, studentShee
   }
 
   function handleDownload() {
-    convertAndExportToXlsx(studentSheetData, 'Estudiantes');
+    convertAndExportToXlsx(studentSheetData, 'Estudiantes', ['Cuota', 'Total deuda']);
   }
 
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,8 @@ const whitelist = [
   'fsoffici01@gmail.com'
 ];
 
+export const dashboardAllowedEmails = ['lautarosoffici@gmail.com', 'julietapontino@gmail.com', 'gsoffici@gmail.com'];
+
 export const authOptions: NextAuthOptions = {
   // Secret for Next-auth, without this JWT encryption/decryption won't work
   secret: process.env.NEXTAUTH_SECRET,

--- a/src/lib/students.ts
+++ b/src/lib/students.ts
@@ -360,6 +360,14 @@ export const getStudentInvoices = async (id: number, searchParams: SearchParams)
 
   const invoices = await prisma.invoice.findMany({
     where: whereClause,
+    include: {
+      items: {
+        select: {
+          receiptId: true
+        },
+        take: 1
+      }
+    },
     orderBy: {
       [sortBy]: sortOrder
     },
@@ -441,6 +449,11 @@ export const getStudentSheetData = async () => {
     },
     include: {
       studentByCourse: {
+        where: {
+          course: {
+            active: true
+          }
+        },
         include: {
           course: true
         },
@@ -464,15 +477,21 @@ export const getStudentSheetData = async () => {
     const courses = student.studentByCourse.map((c) => c.course);
     const expiredInvoices = student.invoices.filter((i) => i.state === InvoiceState.I && i.expiredAt < new Date());
 
+    const totalDebt = expiredInvoices.reduce(
+      (sum, i) => sum + (getDiscountedAmount(i.amount, i.discount) - i.balance),
+      0
+    );
+
     return {
       Alumno: `${student.lastName} ${student.firstName}`,
       Curso: courses.map((c) => c.name).join(', '),
-      Cuota: courses.map((c) => formatCurrency(c.amount)).join(', '),
-      Adeuda: expiredInvoices
+      Cuota: courses.reduce((sum, c) => sum + c.amount, 0),
+      'Detalle deuda': expiredInvoices
         .map(
           (i) => `${getMonthName(i.month)}: ${formatCurrency(getDiscountedAmount(i.amount, i.discount) - i.balance)}`
         )
-        .join(', ')
+        .join(', '),
+      'Total deuda': totalDebt
     };
   });
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -124,8 +124,30 @@ export function getErrorMessage(error: unknown) {
   return toErrorWithMessage(error).message;
 }
 
-export const convertAndExportToXlsx = <T>(data: T[], fileName: string) => {
+export const convertAndExportToXlsx = <T extends Record<string, unknown>>(
+  data: T[],
+  fileName: string,
+  currencyColumns?: string[]
+) => {
   const ws = XLSX.utils.json_to_sheet(data);
+
+  if (currencyColumns && data.length > 0) {
+    const headers = Object.keys(data[0]);
+    const currencyColIndices = currencyColumns
+      .map((col) => headers.indexOf(col))
+      .filter((idx) => idx !== -1);
+
+    for (const colIdx of currencyColIndices) {
+      for (let rowIdx = 1; rowIdx <= data.length; rowIdx++) {
+        const cellRef = XLSX.utils.encode_cell({ r: rowIdx, c: colIdx });
+        const cell = ws[cellRef];
+        if (cell && typeof cell.v === 'number') {
+          cell.z = '"$"#,##0';
+        }
+      }
+    }
+  }
+
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, fileName);
   XLSX.writeFile(wb, `${fileName}.xlsx`);


### PR DESCRIPTION
- Restrict dashboard access: Hide the dashboard page and sidebar link for unauthorized users, based on an allowlist of emails in auth.ts.
- Link paid invoices to receipts: The "Pagado" badge on student invoices now links to the corresponding receipt, opening it in a new tab.
- Fix student list export for Excel: Export "Cuota" and "Total deuda" as numeric values (instead of formatted currency strings) so they can be summed in Excel. 